### PR TITLE
[GDF-4] feat: Implement Reset Password Page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Home from '@pages/Home/Home.tsx';
 import Header from '@components/Header/Header.tsx';
 import Footer from '@components/Footer/Footer.tsx';
+import ResetPassword from '@pages/Home/ResetPassword/ResetPassword';
 import './styles/global.css';
 
 const App: React.FC = () => {
@@ -11,6 +12,7 @@ const App: React.FC = () => {
       <main>
         <Routes>
           <Route path='/' element={<Home />} />
+          <Route path='/reset-password' element={<ResetPassword />} />
         </Routes>
       </main>
       <Footer />

--- a/src/pages/Home/ResetPassword/ResetPassword.css
+++ b/src/pages/Home/ResetPassword/ResetPassword.css
@@ -1,0 +1,62 @@
+.reset-password-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 2rem;
+  background-color: #f5f5f5;
+}
+
+.reset-password-form {
+  background-color: white;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 400px;
+}
+
+.reset-password-form h2 {
+  text-align: center;
+  margin-bottom: 2rem;
+  color: #333;
+}
+
+.form-group {
+  margin-bottom: 1.5rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: #555;
+  font-weight: 500;
+}
+
+.form-group input {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #ddd;
+  background-color: white;
+  color: #333;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.form-group input:focus {
+  outline: none;
+  border-color: #4caf50;
+  box-shadow: 0 0 0 2px rgba(76, 175, 80, 0.2);
+}
+
+.error {
+  display: block;
+  color: #d32f2f;
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+}
+
+button[type='submit'] {
+  width: 100%;
+  margin-top: 1rem;
+}

--- a/src/pages/Home/ResetPassword/ResetPassword.tsx
+++ b/src/pages/Home/ResetPassword/ResetPassword.tsx
@@ -1,0 +1,61 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { resetPasswordSchema, type ResetPasswordFormSchema } from './schema';
+import Button from '@components/Button/Button';
+import './ResetPassword.css';
+
+const ResetPassword = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<ResetPasswordFormSchema>({
+    resolver: zodResolver(resetPasswordSchema),
+  });
+
+  const onSubmit = async (data: ResetPasswordFormSchema) => {
+    try {
+      console.log('Reset Password Data:', data);
+    } catch (error) {
+      console.error('Error resetting password:', error);
+    }
+  };
+
+  return (
+    <div className='reset-password-container'>
+      <form onSubmit={handleSubmit(onSubmit)} className='reset-password-form'>
+        <h2>Reset Password</h2>
+
+        <div className='form-group'>
+          <label htmlFor='password'>New Password</label>
+          <input
+            id='password'
+            type='password'
+            {...register('password')}
+            placeholder='Enter your new password'
+          />
+          {errors.password && <span className='error'>{errors.password.message}</span>}
+        </div>
+
+        <div className='form-group'>
+          <label htmlFor='confirmPassword'>Confirm Password</label>
+          <input
+            id='confirmPassword'
+            type='password'
+            {...register('confirmPassword')}
+            placeholder='Confirm your new password'
+          />
+          {errors.confirmPassword && (
+            <span className='error'>{errors.confirmPassword.message}</span>
+          )}
+        </div>
+
+        <Button type='submit' disabled={isSubmitting}>
+          {isSubmitting ? 'Resetting...' : 'Reset Password'}
+        </Button>
+      </form>
+    </div>
+  );
+};
+
+export default ResetPassword;

--- a/src/pages/Home/ResetPassword/schema.tsx
+++ b/src/pages/Home/ResetPassword/schema.tsx
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const resetPasswordSchema = z
+  .object({
+    password: z.string().min(8, 'Password must be at least 8 characters'),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords don't match",
+    path: ['confirmPassword'],
+  });
+
+export type ResetPasswordFormSchema = z.infer<typeof resetPasswordSchema>;


### PR DESCRIPTION
### **In ResetPassword.tsx**
<details> 
<summary><strong>Reset Password</strong>: Main Reset Password form component with validation</summary>

![image](https://github.com/user-attachments/assets/17475014-d028-4d3d-8ee8-c824aedd94be)

</details>

### **In Schema.tsx**
<details> 
<summary><strong>Schema</strong>: Zod validation schema for Reset Password</summary>

![image](https://github.com/user-attachments/assets/7aa7f6f4-4c6c-4e3c-9eb7-695f3e3cdd7b)

</details>

### **In App.css**
**Added Reset Password route**

![image](https://github.com/user-attachments/assets/2741fc8a-9a86-45e0-9d7c-17d78929bbf3)